### PR TITLE
remove unused named export keyword

### DIFF
--- a/pages/faculty.js
+++ b/pages/faculty.js
@@ -2,7 +2,7 @@ import React from 'react'
 import Layout from '../components/Layout'
 import withRoot from '../components/withRoot'
 
-export class Faculty extends React.Component {
+class Faculty extends React.Component {
   static getInitialProps ({ query: { id } }) {
     return { id }
   }


### PR DESCRIPTION
Removed the unused `export` keyword in the faculty.js file.

Very minor change, but happy I could train that forking/branching/pullrequesting muscle.

edit: Question, if I wanted to make additional changes (making the footer sticky using flexbox), how would I go about that? Another PR that doesn't include this change, a PR that builds on this branch but is unrelated?
edit2: Did what I thought the `contributing.md` file wanted me to do.