### PR TITLE
Sticky footer

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -6,7 +6,6 @@ import classNames from 'classnames'
 
 const styles = theme => ({
   root: {
-    flexGrow: 1,
     marginTop: 30,
     backgroundColor: `${theme.palette.primary[500]}`,
     borderTop: 'solid 3px #998643',

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,7 +1,19 @@
 import React, { Component } from 'react'
+import withStyles from 'material-ui/styles/withStyles'
 import AppBar from './AppBar'
 import Drawer from './Drawer'
 import Footer from './Footer'
+
+const styles = theme => ({
+  layout: {
+    display: 'flex',
+    minHeight: '100vh',
+    flexDirection: 'column'
+  },
+  main: {
+    flex: '1 0 auto'
+  }
+})
 
 class Layout extends Component {
   state = {
@@ -13,15 +25,16 @@ class Layout extends Component {
   }
 
   render () {
+    const { classes } = this.props
     return (
-      <div>
+      <div className={classes.layout}>
         <Drawer open={this.state.drawer} toggleDrawer={this.toggleDrawer} />
         <AppBar toggleDrawer={this.toggleDrawer} />
-        {this.props.children}
+        <main className={classes.main}>{this.props.children}</main>
         <Footer />
       </div>
     )
   }
 }
 
-export default Layout
+export default withStyles(styles)(Layout)

--- a/pages/faculty.js
+++ b/pages/faculty.js
@@ -2,7 +2,7 @@ import React from 'react'
 import Layout from '../components/Layout'
 import withRoot from '../components/withRoot'
 
-export class Faculty extends React.Component {
+class Faculty extends React.Component {
   static getInitialProps ({ query: { id } }) {
     return { id }
   }


### PR DESCRIPTION
includes #27 

Footer now sticks to the bottom, even is the page content is not big enough to fill the entire viewport.

I changed 1 style property in the Footer.js file.
The flexGrow propery caused the footer to expand with empty space.
This feature wasn't asked for, and I don't even know if I did it right, so I expect nothing, only more pull-request exercise.