### PR TITLE
Fix details tag replacement

### DIFF
--- a/e2e/tests/faculty.spec.js
+++ b/e2e/tests/faculty.spec.js
@@ -53,7 +53,8 @@ describe('Faculty', () => {
       })
       const jsonData = await data.json()
       const content = jsonData.data.faculty.edges[0].node.content
-      console.log(JSON.stringify(jsonData, null, 2))
+        .replace(/<Details/g, '<div class="details"')
+        .replace(/<Details/g, '</div')
       const page = await browser.newPage()
       await page.goto(`${opts.appUrl}/faculty/haenni-eric`)
       const CONTENT_SELECTOR = 'div[data-testid*="content"]'

--- a/pages/faculty.js
+++ b/pages/faculty.js
@@ -20,12 +20,16 @@ class Faculty extends Component {
         </Layout>
       )
     }
+    const content = data.faculty.edges[0].node.content
+      .replace(/<Details/g, '<div class="details"')
+      .replace(/<Details/g, '</div')
+    global.x = content
     return (
       <Layout>
         <div
           data-testid="content"
           dangerouslySetInnerHTML={{
-            __html: data.faculty.edges[0].node.content
+            __html: content
           }}
         />
       </Layout>


### PR DESCRIPTION
The issue was that there is bug in js which didnt matched replace in linebreaks.

I have used regexp now.

Now it is also tested in e2e tests