### PR TITLE
fix: center logo on side bar

### DIFF
--- a/components/Drawer.js
+++ b/components/Drawer.js
@@ -25,6 +25,9 @@ const styles = theme => ({
   },
   formControl: {
     margin: theme.spacing.unit
+  },
+  drawerImg: {
+    margin: '0 auto'
   }
 })
 
@@ -53,7 +56,7 @@ class TemporaryDrawer extends React.Component {
               <ListItem>
                 <Link href={'/'}>
                   <img
-                    className="drawerImg"
+                    className={classes.drawerImg}
                     width="200"
                     src="/static/img/fus-logo.svg"
                     alt="logo"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1096,10 +1096,6 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
-base64-js@^1.0.2:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"
-
 batch-processor@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/batch-processor/-/batch-processor-1.0.0.tgz#75c95c32b748e0850d10c2b168f6bdbe9891ace8"
@@ -1293,6 +1289,10 @@ buffer-xor@^1.0.3:
 buffer@^4.3.0:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
 
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
@@ -3380,10 +3380,6 @@ husky@^0.14.3:
 iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
-
-ieee754@^1.1.4:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
 ignore@^3.3.3, ignore@^3.3.6:
   version "3.3.7"


### PR DESCRIPTION
I remove the class string drawerImg and create as a property on the object styles and as value I set the css rule margin: 0 auto so the logo can be centered closes #47 