### PR TITLE
make social icons larger and center them [closes #50]

### DIFF
--- a/components/AppBar.js
+++ b/components/AppBar.js
@@ -31,13 +31,13 @@ const styles = theme => ({
   headerImage: {
     maxHeight: '3rem'
   },
-  // social: {
-  //   position: 'fixed',
-  //   top: '8px',
-  //   right: '116px'
-  // },
+  social: {
+    display: 'flex',
+    alignItems: 'center'
+  },
   svgStyle: {
-    width: '30px',
+    width: 'auto',
+    height: '32px',
     fill: `${theme.palette.primary[500]}`
   },
   // secondaryCTA: {


### PR DESCRIPTION
closes #50 
Centered social icons using flexbox.
Made them bigger (the height value is at 32px now, feel free to change it)

Note to everyone submitting a PR: make sure yarn run dev is running at the moment you commit or the commit will fail.