### PR TITLE
change color of search label and inkbar on focus

### DIFF
--- a/components/Drawer.js
+++ b/components/Drawer.js
@@ -23,6 +23,14 @@ const styles = theme => ({
   },
   drawerImg: {
     margin: '0 auto'
+  },
+  inputLabelFocused: {
+    color: '#998643'
+  },
+  inputInkbar: {
+    '&:after': {
+      backgroundColor: '#998643'
+    }
   }
 })
 
@@ -60,10 +68,20 @@ class TemporaryDrawer extends React.Component {
               </ListItem>
               <ListItem>
                 <FormControl className={classes.formControl}>
-                  <InputLabel htmlFor="search">Search</InputLabel>
+                  <InputLabel
+                    FormControlClasses={{
+                      focused: classes.inputLabelFocused
+                    }}
+                    htmlFor="search"
+                  >
+                    Search
+                  </InputLabel>
                   <Input
                     id="search"
                     type="text"
+                    classes={{
+                      inkbar: classes.inputInkbar
+                    }}
                     value={this.state.search}
                     onChange={this.handleSearchChange}
                     endAdornment={


### PR DESCRIPTION
resolves #46 

The color of the search text that pops out on focus is controlled by
 

```
 inputLabelFocused: {
    color: '#998643'
  },
```
The color or the underline when focussed in controlled by

 ```
 inputInkbar: {
    '&:after': {
      backgroundColor: '#998643'
    }
  }
```

suggestion: put the color that is used inside the Mui-theme and pull it out from there.