### PR TITLE
feat(page,.babelrc): Properly configure apollo client 2.1 react using babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,5 +9,15 @@
     "test": {
       "presets": [["env", { "modules": "commonjs" }], "next/babel"]
     }
-  }
+  },
+  "plugins": [
+    [
+      "module-resolver",
+      {
+        "alias": {
+          "^react-apollo$": "react-apollo/index"
+        }
+      }
+    ]
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^8.1.2",
+    "babel-plugin-module-resolver": "^3.0.0",
     "chai": "^4.1.2",
     "commitizen": "^2.9.6",
     "cz-conventional-changelog": "^2.1.0",

--- a/pages/page.js
+++ b/pages/page.js
@@ -23,8 +23,7 @@ class Page extends Component {
         </Head>
         <Query
           query={PageQuery(this.props.type)}
-          variables={{ name: this.props.id }}
-        >
+          variables={{ name: this.props.id }}>
           {result => {
             if (result.loading) {
               return <h1>Loading</h1>
@@ -37,7 +36,7 @@ class Page extends Component {
               <div
                 data-testid="content"
                 dangerouslySetInnerHTML={{
-                  __html: data.aboutPages.edges[0].node.content
+                  __html: data[this.props.type].edges[0].node.content
                 }}
               />
             )

--- a/pages/page.js
+++ b/pages/page.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
-import { compose } from 'react-apollo'
+import { PageQuery } from '../lib/queries/page'
+import { Query, compose } from 'react-apollo'
 
 import withData from '../lib/withData'
 import Layout from '../components/Layout'
@@ -11,23 +12,6 @@ class Page extends Component {
     return { id, type }
   }
   render () {
-    const { data } = this.props
-    const loading = data.loading
-    const query = gql`
-      query SomeQuery {
-        foo {
-          bar
-          baz
-        }
-      }
-    `
-    if (loading) {
-      return (
-        <Layout>
-          <h1>Loading</h1>
-        </Layout>
-      )
-    }
     return (
       <Layout>
         <Head>
@@ -37,18 +21,31 @@ class Page extends Component {
             type="text/css"
           />
         </Head>
-        <div
-          data-testid="content"
-          dangerouslySetInnerHTML={{
-            __html: data[this.props.type].edges[0].node.content
+        <Query
+          query={PageQuery(this.props.type)}
+          variables={{ name: this.props.id }}
+        >
+          {result => {
+            if (result.loading) {
+              return <h1>Loading</h1>
+            }
+            if (result.error) return <h3>{result.error}</h3>
+
+            const { data } = result
+
+            return (
+              <div
+                data-testid="content"
+                dangerouslySetInnerHTML={{
+                  __html: data.aboutPages.edges[0].node.content
+                }}
+              />
+            )
           }}
-        />
+        </Query>
       </Layout>
     )
   }
 }
 
-export default compose(
-  withRoot,
-  withData
-)(Page)
+export default compose(withRoot, withData)(Page)

--- a/yarn.lock
+++ b/yarn.lock
@@ -690,6 +690,16 @@ babel-plugin-module-resolver@2.7.1:
     glob "^7.1.1"
     resolve "^1.2.0"
 
+babel-plugin-module-resolver@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.0.0.tgz#a2fe5b97f7b809a8bbac18beada0a94d45987c63"
+  dependencies:
+    find-babel-config "^1.1.0"
+    glob "^7.1.2"
+    pkg-up "^2.0.0"
+    reselect "^3.0.1"
+    resolve "^1.4.0"
+
 babel-plugin-react-require@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-react-require/-/babel-plugin-react-require-3.0.0.tgz#2e4e7b4496b93a654a1c80042276de4e4eeb20e3"
@@ -1109,6 +1119,10 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+base64-js@^1.0.2:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"
+
 batch-processor@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/batch-processor/-/batch-processor-1.0.0.tgz#75c95c32b748e0850d10c2b168f6bdbe9891ace8"
@@ -1298,6 +1312,10 @@ buffer-xor@^1.0.3:
 buffer@^4.3.0:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
 
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
@@ -2814,7 +2832,7 @@ finalhandler@1.1.0:
     statuses "~1.3.1"
     unpipe "~1.0.0"
 
-find-babel-config@^1.0.1:
+find-babel-config@^1.0.1, find-babel-config@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.1.0.tgz#acc01043a6749fec34429be6b64f542ebb5d6355"
   dependencies:
@@ -3533,6 +3551,10 @@ husky@^0.14.3:
 iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+
+ieee754@^1.1.4:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
 ignore@^3.3.3, ignore@^3.3.6:
   version "3.3.7"
@@ -5777,7 +5799,7 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-pkg-up@2.0.0:
+pkg-up@2.0.0, pkg-up@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
   dependencies:
@@ -6420,6 +6442,10 @@ require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
+reselect@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -6445,7 +6471,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.6, resolve@^1.2.0, resolve@^1.3.3, resolve@^1.5.0:
+resolve@^1.1.6, resolve@^1.2.0, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
   dependencies:


### PR DESCRIPTION


closes #65 
Phewww. Finally I got this to work.

## ABSOLUTELY DONT FORGET TO YARN AND RESTART THE SERVER. THERE IS A CHANGE IN BABELRC 

There is a issue going on in exports of react apollo 2.1 so to get this to work I need to add a little babel plugin 

https://github.com/apollographql/react-apollo/issues/1591#issuecomment-361864293

Screenshot 
![screenshot from 2018-01-31 14-16-04](https://user-images.githubusercontent.com/22195362/35613613-ad8cadc2-0692-11e8-8b55-0b32e653877b.png)


PS: *FIRST TIME IN LIFE GOT BENIFIT OF WRITING TEST*

there is a breaking change in MUI beta 31 regarding buttons. Our test caught that while I was commiting :smile: 
![screenshot from 2018-01-31 14-19-52](https://user-images.githubusercontent.com/22195362/35613715-deab9d64-0692-11e8-9c12-67e24c2be58e.png)


Which caused this....
![screenshot from 2018-01-31 14-16-52](https://user-images.githubusercontent.com/22195362/35613739-e78155fa-0692-11e8-9e00-1b7567e461a9.png)


~Will be fixing this in next PR~ Fixed the issue in PR #69 :+1: 