### PR TITLE
fix(server.js): prevent errors from _next/ route and extend universal route

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lru-cache": "^4.1.1",
     "material-ui": "^1.0.0-beta.29",
     "material-ui-icons": "^1.0.0-beta.17",
-    "next": "^4.2.1",
+    "next": "^4.2.3",
     "react": "^16.2.0",
     "react-apollo": "^2.1.0-beta.0",
     "react-dom": "^16.2.0",

--- a/server.js
+++ b/server.js
@@ -4,8 +4,26 @@ const LRUCache = require('lru-cache')
 
 const port = parseInt(process.env.PORT, 10) || 3000
 const dev = process.env.NODE_ENV !== 'production'
-const app = next({ dir: '.', dev })
+const app = next({
+  dir: '.',
+  dev
+})
 const handle = app.getRequestHandler()
+
+const translationObj = {
+  faculty: { page: '/faculty' },
+  contact: { page: '/directory' },
+  news: { page: '/news' },
+  major: { page: '/major' },
+  minor: { page: '/minor' },
+  department: { page: '/department' },
+  economics: { page: '/major', id: 'economics' },
+  accounting: { page: '/major', id: 'accounting' },
+  'comm-arts': { page: '/minor', id: 'film-studies-minor' },
+  associate: { page: '/associate' },
+  hr: { page: '/page', type: 'humanResources' },
+  'campus-security': { page: '/page', type: 'campusSecurity' }
+}
 
 // This is where we cache our rendered HTML pages
 const ssrCache = new LRUCache({
@@ -18,87 +36,36 @@ app.prepare().then(() => {
 
   // Use the `renderAndCache` utility defined below to serve pages
   server.get('/', (req, res) => renderAndCache(req, res, '/'))
-  server.get('/faculty/:id', (req, res) =>
-    renderAndCache(req, res, '/faculty', { id: req.params.id })
-  )
-  server.get('/contact/:id', (req, res) =>
-    renderAndCache(req, res, '/directory', { id: req.params.id })
-  )
-  server.get('/news/:id', (req, res) =>
-    renderAndCache(req, res, '/news', { id: req.params.id })
-  )
-
-  // Route to each page individually to one component (like majors) pass in the correct slug manually as the id
-  // Make a proper route (majors/business) and have it go to the same component
-  // server.get('/:id', (req, res) =>
-  //   renderAndCache(req, res, '/major', { id: 'economics' })
-  // )
-
-  // Majors
-  server.get('/economics', (req, res) =>
-    renderAndCache(req, res, '/major', { id: 'economics' })
-  )
-  server.get('/major/:id', (req, res) =>
-    renderAndCache(req, res, '/major', { id: req.params.id })
-  )
-  server.get('/accounting', (req, res) =>
-    renderAndCache(req, res, '/major', { id: 'accounting' })
-  )
-
-  // server.get('/dept/:dept_id/minor/:minor_id', (req, res) =>
-  //   renderAndCache(req, res, '/minor', { id: req.params.id })
-  // )
-
-  // Minors
-  server.get('/comm-arts/film-studies', (req, res) =>
-    renderAndCache(req, res, '/minor', { id: 'film-studies-minor' })
-  )
-
-  server.get('/minor/:id', (req, res) =>
-    renderAndCache(req, res, '/minor', { id: req.params.id })
-  )
 
   // Associate Degree Programs
   server.get('/associate', (req, res) =>
     renderAndCache(req, res, '/associate', { id: 'main' })
   )
 
-  server.get('/associate/:id', (req, res) =>
-    renderAndCache(req, res, '/associate', { id: req.params.id })
-  )
-
-  // Departments
-  // server.get('/department', (req, res) =>
-  //   renderAndCache(req, res, '/departmentList', { id: req.params.id })
-  // )
-
-  server.get('/department/:id', (req, res) =>
-    renderAndCache(req, res, '/department', { id: req.params.id })
-  )
-
-  server.get('/hr/:id', (req, res) =>
-    renderAndCache(req, res, '/page', {
-      id: req.params.id,
-      type: 'humanResources'
-    })
-  )
-
-  server.get('/campus-security/:id', (req, res) =>
-    renderAndCache(req, res, '/page', {
-      id: req.params.id,
-      type: 'campusSecurity'
-    })
-  )
-
-  // // Make a universal Route
+  // universal Route
   server.get('/:type/:id', (req, res, next) => {
     if (req.params.type !== '_next') {
-      renderAndCache(req, res, '/page', {
-        id: req.params.id,
-        type: `${req.params.type}Pages`
-      })
+      const type = translationObj[req.params.type].type
+        ? translationObj[req.params.type].type
+        : null
+      const id = translationObj[req.params.type].id
+        ? translationObj[req.params.type].id
+        : req.params.id
+      const page = translationObj[req.params.type].page
+      let options = {}
+      if (id) {
+        options.id = id
+      }
+      if (type) {
+        options.type = type
+      }
+      console.log(type)
+      console.log(id)
+      console.log(page)
+      console.log(options)
+      return renderAndCache(req, res, page, options)
     }
-    next()
+    return handle(req, res)
   })
 
   server.get('*', (req, res) => {

--- a/server.js
+++ b/server.js
@@ -17,10 +17,10 @@ const translationObj = {
   major: { page: '/major' },
   minor: { page: '/minor' },
   department: { page: '/department' },
-  economics: { page: '/major', id: 'economics' },
-  accounting: { page: '/major', id: 'accounting' },
-  'comm-arts': { page: '/minor', id: 'film-studies-minor' },
-  associate: { page: '/associate' },
+  economics: { page: '/major', id: { default: 'economics' } },
+  accounting: { page: '/major', id: { default: 'accounting' } },
+  'comm-arts': { page: '/minor', id: { 'film-studies': 'film-studies-minor' } },
+  associate: { page: '/associate', id: { default: 'main' } },
   hr: { page: '/page', type: 'humanResources' },
   'campus-security': { page: '/page', type: 'campusSecurity' }
 }
@@ -37,21 +37,38 @@ app.prepare().then(() => {
   // Use the `renderAndCache` utility defined below to serve pages
   server.get('/', (req, res) => renderAndCache(req, res, '/'))
 
-  // Associate Degree Programs
-  server.get('/associate', (req, res) =>
-    renderAndCache(req, res, '/associate', { id: 'main' })
-  )
-
   // universal Route
   server.get('/:type/:id', (req, res, next) => {
     if (req.params.type !== '_next') {
-      const type = translationObj[req.params.type].type
-        ? translationObj[req.params.type].type
-        : null
-      const id = translationObj[req.params.type].id
-        ? translationObj[req.params.type].id
-        : req.params.id
-      const page = translationObj[req.params.type].page
+      let type = null
+      if (req.params.type) {
+        type = `${req.params.type}Pages`
+        if (translationObj[req.params.type]) {
+          if (translationObj[req.params.type].type) {
+            type = translationObj[req.params.type].type
+          }
+        }
+      }
+      let id = null
+      if (req.params.id) {
+        if (translationObj[req.params.type].id) {
+          if (translationObj[req.params.type].id[req.params.id]) {
+            id = translationObj[req.params.type].id[req.params.id]
+          }
+        } else {
+          id = req.params.id
+        }
+      } else {
+        id = translationObj[req.params.type].id.default
+          ? translationObj[req.params.type].id.default
+          : null
+      }
+      let page = '/page'
+      if (translationObj[req.params.type]) {
+        if (translationObj[req.params.type].page) {
+          page = translationObj[req.params.type].page
+        }
+      }
       let options = {}
       if (id) {
         options.id = id

--- a/server.js
+++ b/server.js
@@ -90,12 +90,14 @@ app.prepare().then(() => {
     })
   )
 
-  // Make a universal Route
+  // // Make a universal Route
   server.get('/:type/:id', (req, res) => {
-    renderAndCache(req, res, '/page', {
-      id: req.params.id,
-      type: `${req.params.type}Pages`
-    })
+    if (req.params.type !== '_next') {
+      renderAndCache(req, res, '/page', {
+        id: req.params.id,
+        type: `${req.params.type}Pages`
+      })
+    }
   })
 
   server.get('*', (req, res) => {

--- a/server.js
+++ b/server.js
@@ -91,13 +91,14 @@ app.prepare().then(() => {
   )
 
   // // Make a universal Route
-  server.get('/:type/:id', (req, res) => {
+  server.get('/:type/:id', (req, res, next) => {
     if (req.params.type !== '_next') {
       renderAndCache(req, res, '/page', {
         id: req.params.id,
         type: `${req.params.type}Pages`
       })
     }
+    next()
   })
 
   server.get('*', (req, res) => {

--- a/server.js
+++ b/server.js
@@ -38,7 +38,7 @@ app.prepare().then(() => {
   server.get('/', (req, res) => renderAndCache(req, res, '/'))
 
   // universal Route
-  server.get('/:type/:id', (req, res, next) => {
+  server.get('/:type/:id?', (req, res, next) => {
     if (req.params.type !== '_next') {
       let type = null
       if (req.params.type) {
@@ -59,9 +59,11 @@ app.prepare().then(() => {
           id = req.params.id
         }
       } else {
-        id = translationObj[req.params.type].id.default
-          ? translationObj[req.params.type].id.default
-          : null
+        if (translationObj[req.params.type].id) {
+          if (translationObj[req.params.type].id.default) {
+            id = translationObj[req.params.type].id.default
+          }
+        }
       }
       let page = '/page'
       if (translationObj[req.params.type]) {
@@ -76,10 +78,10 @@ app.prepare().then(() => {
       if (type) {
         options.type = type
       }
-      console.log(type)
-      console.log(id)
-      console.log(page)
-      console.log(options)
+      // console.log('type:', type)
+      // console.log('id:', id)
+      // console.log('page:', page)
+      // console.log('options:', options)
       return renderAndCache(req, res, page, options)
     }
     return handle(req, res)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5602,7 +5602,7 @@ netrc@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/netrc/-/netrc-0.1.4.tgz#6be94fcaca8d77ade0a9670dc460914c94472444"
 
-next@^4.2.1:
+next@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/next/-/next-4.2.3.tgz#6f85f9bd6df2c420b4f6425f9f158e82515b7bc8"
   dependencies:


### PR DESCRIPTION
fix #71, fix #72 

This prevents the errors in the console from accumulating and enables HMR again while keeping the universal route functional.
This also extends to universal route to catch all current (and hopefully future) routes, using a translation object.

### This PR also updates Next to 4.2.3, remember to run yarn