### PR TITLE
Routing rework

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach by Process ID",
+      "processId": "${command:PickProcess}"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "program": "${workspaceFolder}\\n\\a"
+    }
+  ]
+}

--- a/pages/hat.js
+++ b/pages/hat.js
@@ -1,0 +1,15 @@
+import React, { Component } from 'react'
+
+export default class Hat extends Component {
+  static async getInitialProps ({ query: { id } }) {
+    console.log(id)
+    return { id }
+  }
+  render () {
+    return (
+      <div>
+        <p>Page for hat with id: {this.props.id}</p>
+      </div>
+    )
+  }
+}

--- a/pages/hatList.js
+++ b/pages/hatList.js
@@ -1,0 +1,25 @@
+import React, { Component } from 'react'
+import Link from 'next/link'
+
+export default class HatList extends Component {
+  render () {
+    return (
+      <div>
+        <ul>
+          <li>
+            <Link href="/hats/1">hat 1</Link>
+          </li>
+          <li>
+            <Link href="/hats/Silly-hat">silly hat</Link>
+          </li>
+          <li>
+            <Link href="/hats/3">hat 3</Link>
+          </li>
+          <li>
+            <Link href="/hats/blue">Blue hat</Link>
+          </li>
+        </ul>
+      </div>
+    )
+  }
+}

--- a/server-old.js
+++ b/server-old.js
@@ -1,0 +1,256 @@
+const express = require('express')
+const next = require('next')
+const LRUCache = require('lru-cache')
+
+const port = parseInt(process.env.PORT, 10) || 3000
+const dev = process.env.NODE_ENV !== 'production'
+const app = next({
+  dir: '.',
+  dev
+})
+const handle = app.getRequestHandler()
+
+const translationObj = {
+  faculty: { page: '/faculty', type: 'faculty' },
+  contact: { page: '/directory' },
+  news: { page: '/news' },
+  search: { page: '/search' },
+  major: { page: '/major' },
+  minor: { page: '/minor' },
+  department: { page: '/department' },
+  economics: { page: '/major', type: 'majors', id: { default: 'economics' } },
+  accounting: { page: '/major', type: 'majors', id: { default: 'accounting' } },
+  politicalscience: {
+    page: '/major',
+    type: 'majors',
+    id: { default: 'politicalscience' }
+  },
+  'political-science': {
+    page: '/major',
+    type: 'majors',
+    id: { default: 'politicalscience' }
+  },
+  sacredmusic: {
+    page: '/major',
+    type: 'majors',
+    id: { default: 'sacred-music' }
+  },
+  'sacred-music': {
+    page: '/major',
+    type: 'majors',
+    id: { default: 'sacred-music' }
+  },
+  'comm-arts': {
+    page: '/minor',
+    id: { 'film-studies': 'film-studies-minor' }
+  },
+  associate: { page: '/associate', id: { default: 'main' } },
+  studentlife: {
+    page: '/page',
+    type: 'studentLifePages',
+    id: { default: 'student-life' }
+  },
+  households: {
+    page: '/page',
+    type: 'householdsPages',
+    id: { default: 'main' }
+  },
+  excite: {
+    page: '/page',
+    type: 'studentLifePages',
+    id: { default: 'excite' }
+  },
+  baronday: {
+    page: '/page',
+    type: 'admissionsPages',
+    id: { default: 'baron-day' }
+  },
+  academics: {
+    page: '/page'
+  },
+  hr: { page: '/page', type: 'humanResources' },
+  'campus-security': { page: '/page', type: 'campusSecurity' },
+  studentprofiles: { page: '/faculty', type: 'studentProfilePages' }
+}
+
+// This is where we cache our rendered HTML pages
+const ssrCache = new LRUCache({
+  max: 100,
+  maxAge: dev ? 5 : 1000 * 60 * 60 // 1hour
+})
+
+app.prepare().then(() => {
+  const server = express()
+
+  // Use the `renderAndCache` utility defined below to serve pages
+  server.get('/', (req, res) => renderAndCache(req, res, '/'))
+
+  // universal Route
+  server.get('/:type/:id?', (req, res, next) => {
+    req.params.type = req.params.type ? req.params.type.toLowerCase() : null
+    req.params.id = req.params.id ? req.params.id.toLowerCase() : null
+    if (
+      req.params.type !== '_next' &&
+      req.params.type !== 'robots.txt' &&
+      req.params.type !== 'service-worker.js' &&
+      req.params.type !== 'favicon.ico'
+    ) {
+      let type = null
+      if (req.params.type) {
+        type = `${req.params.type}Pages`
+        if (translationObj[req.params.type]) {
+          if (translationObj[req.params.type].type) {
+            type = translationObj[req.params.type].type
+          }
+        } else {
+          return renderAndCache(req, res, '/page', {
+            id: req.params.id,
+            type: `${req.params.type}Pages`
+          })
+        }
+      }
+      let id = null
+      if (req.params.id) {
+        if (translationObj[req.params.type].id) {
+          if (req.params.id) {
+            id = req.params.id
+          } else if (translationObj[req.params.type].id[req.params.id]) {
+            id = translationObj[req.params.type].id[req.params.id]
+          }
+        } else {
+          id = req.params.id
+        }
+      } else {
+        if (translationObj[req.params.type].id) {
+          if (translationObj[req.params.type].id.default) {
+            id = translationObj[req.params.type].id.default
+          }
+        }
+      }
+      let page = '/page'
+      if (translationObj[req.params.type]) {
+        if (translationObj[req.params.type].page) {
+          page = translationObj[req.params.type].page
+        }
+      }
+      let options = {}
+      if (id) {
+        options.id = id
+      }
+      if (type) {
+        options.type = type
+      }
+      console.log('type:', type)
+      console.log('id:', id)
+      console.log('page:', page)
+      console.log('options:', options)
+      return renderAndCache(req, res, page, options)
+    }
+    return handle(req, res)
+  })
+
+  server.get('/:type/:subtype/:id?', (req, res, next) => {
+    req.params.type = req.params.type ? req.params.type.toLowerCase() : null
+    req.params.id = req.params.id ? req.params.id.toLowerCase() : null
+    if (
+      req.params.type !== '_next' &&
+      req.params.type !== 'robots.txt' &&
+      req.params.type !== 'service-worker.js' &&
+      req.params.type !== 'favicon.ico' &&
+      req.params.type !== 'static'
+    ) {
+      let type = null
+      if (req.params.type) {
+        type = `${req.params.type}Pages`
+        if (translationObj[req.params.type]) {
+          if (translationObj[req.params.type].type) {
+            type = translationObj[req.params.type].type
+          }
+        } else {
+          return renderAndCache(req, res, '/page', {
+            id: req.params.id,
+            type: `${req.params.type}Pages`
+          })
+        }
+      }
+      let id = null
+      if (req.params.id) {
+        if (translationObj[req.params.type].id) {
+          if (req.params.id) {
+            id = req.params.id
+          } else if (translationObj[req.params.type].id[req.params.id]) {
+            id = translationObj[req.params.type].id[req.params.id]
+          }
+        } else {
+          id = req.params.id
+        }
+      } else {
+        if (translationObj[req.params.type].id) {
+          if (translationObj[req.params.type].id.default) {
+            id = translationObj[req.params.type].id.default
+          }
+        }
+      }
+      let page = '/page'
+      if (translationObj[req.params.type]) {
+        if (translationObj[req.params.type].page) {
+          page = translationObj[req.params.type].page
+        }
+      }
+      let options = {}
+      if (id) {
+        options.id = id
+      }
+      if (type) {
+        options.type = type
+      }
+      console.log('type:', type)
+      console.log('id:', id)
+      console.log('page:', page)
+      console.log('options:', options)
+      return renderAndCache(req, res, page, options)
+    }
+    return handle(req, res)
+  })
+  server.get('*', (req, res) => {
+    return handle(req, res)
+  })
+
+  server.listen(port, err => {
+    if (err) throw err
+    console.log(`> Ready on http://localhost:${port}`)
+  })
+})
+
+/*
+ * NB: make sure to modify this to take into account anything that should trigger
+ * an immediate page change (e.g a locale stored in req.session)
+ */
+function getCacheKey (req) {
+  return `${req.url}`
+}
+
+function renderAndCache (req, res, pagePath, queryParams) {
+  const key = getCacheKey(req)
+
+  // If we have a page in the cache, let's serve it
+  if (ssrCache.has(key)) {
+    console.log(`CACHE HIT: ${key}`)
+    res.send(ssrCache.get(key))
+    return
+  }
+
+  // If not let's render the page into HTML
+  app
+    .renderToHTML(req, res, pagePath, queryParams)
+    .then(html => {
+      // Let's cache this page
+      console.log(`CACHE MISS: ${key}`)
+      ssrCache.set(key, html)
+
+      res.send(html)
+    })
+    .catch(err => {
+      app.renderError(err, req, res, pagePath, queryParams)
+    })
+}

--- a/server.js
+++ b/server.js
@@ -4,10 +4,7 @@ const LRUCache = require('lru-cache')
 
 const port = parseInt(process.env.PORT, 10) || 3000
 const dev = process.env.NODE_ENV !== 'production'
-const app = next({
-  dir: '.',
-  dev
-})
+const app = next({ dir: '.', dev })
 const handle = app.getRequestHandler()
 
 const translationObj = {
@@ -85,133 +82,33 @@ app.prepare().then(() => {
   // Use the `renderAndCache` utility defined below to serve pages
   server.get('/', (req, res) => renderAndCache(req, res, '/'))
 
-  // universal Route
-  server.get('/:type/:id?', (req, res, next) => {
-    req.params.type = req.params.type ? req.params.type.toLowerCase() : null
-    req.params.id = req.params.id ? req.params.id.toLowerCase() : null
+  server.get('/:first/:second?/:third?', (req, res, next) => {
+    // Prevent routes that should not be handled by this logic and send them to the next route in line
     if (
-      req.params.type !== '_next' &&
-      req.params.type !== 'robots.txt' &&
-      req.params.type !== 'service-worker.js' &&
-      req.params.type !== 'favicon.ico'
+      req.params.first !== '_next' &&
+      req.params.first !== 'robots.txt' &&
+      req.params.first !== 'service-worker.js' &&
+      req.params.first !== 'favicon.ico' &&
+      req.params.first !== 'static' &&
+      req.params.first !== 'json'
     ) {
-      let type = null
-      if (req.params.type) {
-        type = `${req.params.type}Pages`
-        if (translationObj[req.params.type]) {
-          if (translationObj[req.params.type].type) {
-            type = translationObj[req.params.type].type
-          }
-        } else {
-          return renderAndCache(req, res, '/page', {
-            id: req.params.id,
-            type: `${req.params.type}Pages`
-          })
-        }
-      }
-      let id = null
-      if (req.params.id) {
-        if (translationObj[req.params.type].id) {
-          if (req.params.id) {
-            id = req.params.id
-          } else if (translationObj[req.params.type].id[req.params.id]) {
-            id = translationObj[req.params.type].id[req.params.id]
-          }
-        } else {
-          id = req.params.id
-        }
-      } else {
-        if (translationObj[req.params.type].id) {
-          if (translationObj[req.params.type].id.default) {
-            id = translationObj[req.params.type].id.default
-          }
-        }
-      }
-      let page = '/page'
-      if (translationObj[req.params.type]) {
-        if (translationObj[req.params.type].page) {
-          page = translationObj[req.params.type].page
-        }
-      }
+      let page = '/'
       let options = {}
-      if (id) {
-        options.id = id
+      if (Object.values(req.params).filter(Boolean).length === 1) {
+        // Logic for routes with 1 parameter
+        console.log('one parameter')
+      } else if (Object.values(req.params).filter(Boolean).length === 2) {
+        // Logic for routes with 2 parameters
+        console.log('two parameters')
+      } else if (Object.values(req.params).filter(Boolean).length === 3) {
+        // Logic for routes with 3 parameters
+        console.log('three parameters')
       }
-      if (type) {
-        options.type = type
-      }
-      console.log('type:', type)
-      console.log('id:', id)
-      console.log('page:', page)
-      console.log('options:', options)
       return renderAndCache(req, res, page, options)
     }
-    return handle(req, res)
+    return next()
   })
 
-  server.get('/:type/:subtype/:id?', (req, res, next) => {
-    req.params.type = req.params.type ? req.params.type.toLowerCase() : null
-    req.params.id = req.params.id ? req.params.id.toLowerCase() : null
-    if (
-      req.params.type !== '_next' &&
-      req.params.type !== 'robots.txt' &&
-      req.params.type !== 'service-worker.js' &&
-      req.params.type !== 'favicon.ico' &&
-      req.params.type !== 'static'
-    ) {
-      let type = null
-      if (req.params.type) {
-        type = `${req.params.type}Pages`
-        if (translationObj[req.params.type]) {
-          if (translationObj[req.params.type].type) {
-            type = translationObj[req.params.type].type
-          }
-        } else {
-          return renderAndCache(req, res, '/page', {
-            id: req.params.id,
-            type: `${req.params.type}Pages`
-          })
-        }
-      }
-      let id = null
-      if (req.params.id) {
-        if (translationObj[req.params.type].id) {
-          if (req.params.id) {
-            id = req.params.id
-          } else if (translationObj[req.params.type].id[req.params.id]) {
-            id = translationObj[req.params.type].id[req.params.id]
-          }
-        } else {
-          id = req.params.id
-        }
-      } else {
-        if (translationObj[req.params.type].id) {
-          if (translationObj[req.params.type].id.default) {
-            id = translationObj[req.params.type].id.default
-          }
-        }
-      }
-      let page = '/page'
-      if (translationObj[req.params.type]) {
-        if (translationObj[req.params.type].page) {
-          page = translationObj[req.params.type].page
-        }
-      }
-      let options = {}
-      if (id) {
-        options.id = id
-      }
-      if (type) {
-        options.type = type
-      }
-      console.log('type:', type)
-      console.log('id:', id)
-      console.log('page:', page)
-      console.log('options:', options)
-      return renderAndCache(req, res, page, options)
-    }
-    return handle(req, res)
-  })
   server.get('*', (req, res) => {
     return handle(req, res)
   })

--- a/server.js
+++ b/server.js
@@ -83,28 +83,55 @@ app.prepare().then(() => {
   server.get('/', (req, res) => renderAndCache(req, res, '/'))
 
   server.get('/:first/:second?/:third?', (req, res, next) => {
+    const firstParam = req.params.first ? req.params.first.toLowerCase() : null
+    const secondParam = req.params.second
+      ? req.params.second.toLowerCase()
+      : null
+    const thirdParam = req.params.third ? req.params.third.toLowerCase() : null
     // Prevent routes that should not be handled by this logic and send them to the next route in line
     if (
-      req.params.first !== '_next' &&
-      req.params.first !== 'robots.txt' &&
-      req.params.first !== 'service-worker.js' &&
-      req.params.first !== 'favicon.ico' &&
-      req.params.first !== 'static' &&
-      req.params.first !== 'json'
+      firstParam !== '_next' &&
+      firstParam !== 'robots.txt' &&
+      firstParam !== 'service-worker.js' &&
+      firstParam !== 'favicon.ico' &&
+      firstParam !== 'static' &&
+      firstParam !== 'json'
     ) {
-      let page = '/'
-      let options = {}
+      let page = '/page'
+      let type = `${firstParam}Pages`
+      let subtype = null
+      let id = null
       if (Object.values(req.params).filter(Boolean).length === 1) {
         // Logic for routes with 1 parameter
         console.log('one parameter')
       } else if (Object.values(req.params).filter(Boolean).length === 2) {
         // Logic for routes with 2 parameters
         console.log('two parameters')
+        // Set up default values for routes with 2 parameters
+        page = '/page'
+        type = firstParam
+        id = secondParam
+
+        if (translationObj[firstParam]) {
+          // find page
+          if (translationObj[firstParam].page) {
+            page = translationObj[firstParam].page
+          }
+          // find type
+          if (translationObj[firstParam].type) {
+            type = translationObj[firstParam].type
+          }
+          // find id
+          if (translationObj[firstParam].id) {
+            id = translationObj[firstParam].id[secondParam]
+          }
+        }
       } else if (Object.values(req.params).filter(Boolean).length === 3) {
         // Logic for routes with 3 parameters
         console.log('three parameters')
       }
-      return renderAndCache(req, res, page, options)
+
+      return renderAndCache(req, res, page, { id, type })
     }
     return next()
   })

--- a/server.js
+++ b/server.js
@@ -105,6 +105,25 @@ app.prepare().then(() => {
       if (Object.values(req.params).filter(Boolean).length === 1) {
         // Logic for routes with 1 parameter
         console.log('one parameter')
+        // Set up default values for routes with 1 parameter
+        page = '/page'
+        type = `${firstParam}Pages`
+        if (translationObj[firstParam]) {
+          // find page
+          if (translationObj[firstParam].page) {
+            page = translationObj[firstParam].page
+          }
+          // find type
+          if (translationObj[firstParam].type) {
+            type = translationObj[firstParam].type
+          }
+          // find id
+          if (translationObj[firstParam].id) {
+            if (translationObj[firstParam].id.default) {
+              id = translationObj[firstParam].id.default
+            }
+          }
+        }
       } else if (Object.values(req.params).filter(Boolean).length === 2) {
         // Logic for routes with 2 parameters
         console.log('two parameters')

--- a/server.js
+++ b/server.js
@@ -67,7 +67,8 @@ const translationObj = {
   },
   hr: { page: '/page', type: 'humanResources' },
   'campus-security': { page: '/page', type: 'campusSecurity' },
-  studentprofiles: { page: '/faculty', type: 'studentProfilePages' }
+  studentprofiles: { page: '/faculty', type: 'studentProfilePages' },
+  hats: { page: { standard: '/hat', default: '/hatList' } }
 }
 
 // This is where we cache our rendered HTML pages
@@ -111,7 +112,11 @@ app.prepare().then(() => {
         if (translationObj[firstParam]) {
           // find page
           if (translationObj[firstParam].page) {
-            page = translationObj[firstParam].page
+            if (typeof translationObj[firstParam].page === 'object') {
+              page = translationObj[firstParam].page.default
+            } else {
+              page = translationObj[firstParam].page
+            }
           }
           // find type
           if (translationObj[firstParam].type) {
@@ -134,7 +139,11 @@ app.prepare().then(() => {
         if (translationObj[firstParam]) {
           // find page
           if (translationObj[firstParam].page) {
-            page = translationObj[firstParam].page
+            if (typeof translationObj[firstParam].page === 'object') {
+              page = translationObj[firstParam].page.standard
+            } else {
+              page = translationObj[firstParam].page
+            }
           }
           // find type
           if (translationObj[firstParam].type) {

--- a/server.js
+++ b/server.js
@@ -97,6 +97,7 @@ app.prepare().then(() => {
       firstParam !== 'static' &&
       firstParam !== 'json'
     ) {
+      // initialize variables
       let page = '/page'
       let type = `${firstParam}Pages`
       let subtype = null
@@ -109,9 +110,8 @@ app.prepare().then(() => {
         console.log('two parameters')
         // Set up default values for routes with 2 parameters
         page = '/page'
-        type = firstParam
+        type = `${firstParam}Pages`
         id = secondParam
-
         if (translationObj[firstParam]) {
           // find page
           if (translationObj[firstParam].page) {
@@ -129,9 +129,17 @@ app.prepare().then(() => {
       } else if (Object.values(req.params).filter(Boolean).length === 3) {
         // Logic for routes with 3 parameters
         console.log('three parameters')
+        // Set up default values for routes with 3 parameters
+        page = '/page'
+        type = `${firstParam}Pages`
+        subtype = secondParam
+        id = thirdParam
+        // find page
+        // find type
+        // find subtype
+        // find id
       }
-
-      return renderAndCache(req, res, page, { id, type })
+      return renderAndCache(req, res, page, { id, type, subtype })
     }
     return next()
   })


### PR DESCRIPTION

Changed the way the routing works.
### **Please help me test** routes 
and tell me what doesn't work.

The code still uses a bunch of guarding `if`-statements for the moment but the logic should be easier to follow.
It fills all the variables that are used by `renderAndCache` with the right information.
At the end of the logic tree, it uses those values and actually calls `renderAndCache` with them

* [x] Rewrite skeleton for routing logic and make the logic more clear to follow
* [x] Merge universal routes for 2 and 3 parameters
* [x] Add logic for routes with 1 parameter
* [x] Add logic for routes with 2 parameters
* [x] Add logic for routes with 3 parameters
* [ ] Make all routes work
* [x] Expand `page` key in the `translationObject `to support multiple pages
* [ ] Rewrite to shorten and eliminate duplicate code
* [ ] Remove `vscode` folder and `server-old.js` from PR

On page key expansion:
Now you can use a different page (a file in the pages folder) for higher level links (eg `/hats`)
than for lower level links (eg. `/hats/blue`).
I added a quick example of this. You can now go to `/hats` and the page used will be `hatList.js`
If you go to `/hats/blue` the page used will be `hat.js`
What is everybody's opinion on how it works? I added to option to make the `page` key in the `translationObject` into an object instead of a string. For higher level links, the `default` key in that object will be used. For lower level links, the `standard` key will be used (I know, terrible naming, suggestions more than welcome)