### PR TITLE
fix(search.js): update state immutably

### DIFF
--- a/pages/search.js
+++ b/pages/search.js
@@ -126,11 +126,20 @@ class Page extends Component {
   }
 
   handleChange = name => (event, checked) => {
-    let checkboxes = this.state.checkboxes
-    checkboxes[name] = checked
-    this.setState({ checkboxes })
-    this.createSearchTypes()
-    this.debouncedSearch()
+    this.setState(
+      prevState => {
+        return {
+          checkboxes: {
+            ...prevState.checkboxes,
+            [name]: checked
+          }
+        }
+      },
+      () => {
+        this.createSearchTypes()
+        this.debouncedSearch()
+      }
+    )
   }
 
   createSearchTypes = () => {


### PR DESCRIPTION
Updated state in an immutable way in the onChange handler for the checkboxes.
Only called `createSeachTypes` after the `setState` is complete

More info on why:
https://medium.freecodecamp.org/handling-state-in-react-four-immutable-approaches-to-consider-d1f5c00249d5

https://reactjs.org/docs/react-component.html#setstate