### PR TITLE
fix(/lib/queries/facultyList.js): Changed search string to slug

### DIFF
--- a/lib/queries/facultyList.js
+++ b/lib/queries/facultyList.js
@@ -2,8 +2,8 @@ import gql from 'graphql-tag'
 
 export const FacultyListQuery = type => {
   return gql`
-    query FacultyListQuery($name: [String]) {
-      facultyDepartments(where: { name: $name }) {
+    query FacultyListQuery($slug: [String]) {
+      facultyDepartments(where: { slug: $slug }) {
         edges {
           node {
             name


### PR DESCRIPTION
The original query was a 'whiteboard' build. $slug should have been the original search field.
mostly partial fix to issue #110

With the exception of one facultyDepartment, this fixes the multi-word slug issue. "Fine Arts" s the only one that removed the space entirely, instead of replacing it with a hyphen.

The following returns all of the department names and their slugs, showing that Fine Arts is the outsider.

````
{
  facultyDepartments (first: 100) {
    edges {
      node {
        name
        slug
      }
    }
  }
}
````

