### PR TITLE
Fix npm command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ project directory, open your terminal, and use:
 
 ```bash
 > npm install
-> npm dev
+> npm run dev
 ```
 
 Now Fork the project from [here](https://github.com/fus-marcom/franciscan-react), make your changes and open a [Pull](https://github.com/fus-marcom/franciscan-react/pulls) Request.


### PR DESCRIPTION
`npm dev` returns the help for npm because it isn't an acceptable command, however, `npm run dev` runs the npm script titled `dev`.

Thus I changed it in the README file.