### PR TITLE
Changed Hero subtitle marginBottom from 0.35em to 1.35em

### DIFF
--- a/components/Hero.js
+++ b/components/Hero.js
@@ -59,7 +59,7 @@ class Hero extends Component {
       <Typography
         className={classes.white}
         variant="subheading"
-        style={{ fontWeight: 500, fontSize: '22px' }}
+        style={{ fontWeight: 500, fontSize: '22px', marginBottom: '1.35em' }}
         gutterBottom
       >
         {subtitleText}


### PR DESCRIPTION
This is to fix [issue #134](https://github.com/fus-marcom/franciscan-react/issues/134). I have changed the following on the _Subtitle_ in `<Hero>`:

```css
margin-bottom: 0.35em;
```
to
```css
margin-bottom: 1.35em;
```