### PR TITLE
Get /faculty GraphQL to return appropriate response, aka no errors; r…

### DIFF
--- a/lib/queries/profile.js
+++ b/lib/queries/profile.js
@@ -2,7 +2,7 @@ import gql from 'graphql-tag'
 
 export const ProfileQuery = type => {
   return gql`
-  query ProfileQuery($name: String!) {
+  query ProfileQuery($name: String) {
     ${type}(where: { name: $name }) {
       edges {
         node {

--- a/pages/faculty.js
+++ b/pages/faculty.js
@@ -69,7 +69,7 @@ class Faculty extends Component {
                 .map(image => `${image.src} ${image.width}w`)
                 .join(',')
 
-            return faculty.map(({ node: facultyMember }, index) => (
+            return faculty.map(({ node: facultyMember }) => (
               <div className={classes.container} key={facultyMember.id}>
                 <h1>{facultyMember.displayNameField.value}</h1>
                 <Grid style={styles.listGridContainer} container spacing={24}>

--- a/pages/faculty.js
+++ b/pages/faculty.js
@@ -37,81 +37,87 @@ class Faculty extends Component {
             const imgRegex = /(<img.src=")(.+)(")(.+)(\/>)/gi
 
             const { data } = result
-            const faculty = data[this.props.type].edges[0].node
-            const content = data[this.props.type].edges[0].node.content.replace(
-              imgRegex,
-              '<img src="https://storage.googleapis.com/fus-wp-storage/$2" $4 />'
-            )
+            const faculty = data[this.props.type].edges
 
-            // const thumbnail =
-            //   faculty.featuredImage &&
-            //   faculty.featuredImage.mediaDetails.sizes.find(
-            //     image => image.name === 'thumbnail'
-            //   ).sourceUrl
-            // const medium =
-            //   faculty.featuredImage &&
-            //   faculty.featuredImage.mediaDetails.sizes.find(
-            //     image => image.name === 'medium'
-            //   ).sourceUrl
+            const getImageData = (facultyMember, size) => {
+              const {
+                sourceUrl,
+                width
+              } = facultyMember.featuredImage.mediaDetails.sizes.find(
+                ({ name }) => name === size
+              )
+              return {
+                // remove end of url and append filename of image
+                src:
+                  facultyMember.featuredImage.sourceUrl.replace(
+                    /(.*\/)[^/]+$/,
+                    '$1'
+                  ) + sourceUrl,
+                width
+              }
+            }
+            const getAllImageData = facultyMember =>
+              ['thumbnail', 'medium']
+                .map(s => getImageData(facultyMember, s))
+                .concat({
+                  src: facultyMember.featuredImage.sourceUrl,
+                  width: facultyMember.featuredImage.mediaDetails.width
+                })
 
-            // const thumbnailW =
-            //   faculty.featuredImage &&
-            //   faculty.featuredImage.mediaDetails.sizes.find(
-            //     image => image.name === 'thumbnail'
-            //   ).width
-            // const mediumW =
-            //   faculty.featuredImage &&
-            //   faculty.featuredImage.mediaDetails.sizes.find(
-            //     image => image.name === 'medium'
-            //   ).width
-            // const imageW =
-            // faculty.featuredImage && faculty.featuredImage.mediaDetails.width
+            const getSrcSet = facultyMember =>
+              getAllImageData(facultyMember)
+                .map(image => `${image.src} ${image.width}w`)
+                .join(',')
 
-            return (
-              <div className={classes.container}>
-                <h1>{faculty.displayNameField.value}</h1>
+            return faculty.map(({ node: facultyMember }, index) => (
+              <div className={classes.container} key={facultyMember.id}>
+                <h1>{facultyMember.displayNameField.value}</h1>
                 <Grid style={styles.listGridContainer} container spacing={24}>
-                  {faculty.featuredImage && (
+                  {facultyMember.featuredImage && (
                     <Grid style={styles.listGridItem} item xs={12} sm={6}>
                       <img
-                        // srcSet={`${thumbnail}  ${thumbnailW}w,
-                        // ${medium}  ${mediumW}w,
-                        // ${faculty.featuredImage.sourceUrl} ${imageW}w`}
-                        // sizes={`(max-width: 320px) 280px,
-                        // (max-width: 480px) 440px,
-                        // 800px`}
-                        src={faculty.featuredImage.sourceUrl}
-                        alt={faculty.featuredImage.altText}
+                        srcSet={getSrcSet(facultyMember)}
+                        sizes={`
+                            (max-width: 320px) 280px,
+                            (max-width: 480px) 440px,
+                            800px
+                          `}
+                        alt={facultyMember.featuredImage.altText}
                       />
                     </Grid>
                   )}
                   <Grid style={styles.listGridItem} item xs={12} sm={6}>
-                    {faculty.jobTitleField.value && (
+                    {facultyMember.jobTitleField.value && (
                       <span className={classes.infoRow}>
-                        {faculty.jobTitleField.value}
+                        {facultyMember.jobTitleField.value}
                       </span>
                     )}
 
-                    {faculty.emailField.value && (
+                    {facultyMember.emailField.value && (
                       <span className={classes.infoRow}>
-                        {faculty.emailField.value}
+                        {facultyMember.emailField.value}
                       </span>
                     )}
-                    {faculty.phoneField.value && (
+                    {facultyMember.phoneField.value && (
                       <span className={classes.infoRow}>
-                        {faculty.phoneField.value}
+                        {facultyMember.phoneField.value}
                       </span>
                     )}
                   </Grid>
                 </Grid>
                 <div
                   dangerouslySetInnerHTML={{
-                    __html: content
+                    __html: facultyMember.content.replace(
+                      imgRegex,
+                      '<img src="https://storage.googleapis.com/fus-wp-storage/$2" $4 />'
+                    )
                   }}
                 />
-                {faculty.cvField && <a href={faculty.cvField.value}>View CV</a>}
+                {facultyMember.cvField && (
+                  <a href={facultyMember.cvField.value}>View CV</a>
+                )}
               </div>
-            )
+            ))
           }}
         </Query>
       </Layout>
@@ -121,9 +127,12 @@ class Faculty extends Component {
 const styles = theme => ({
   container: {
     maxWidth: '90%',
-    margin: '0 auto',
+    margin: '0 auto 4rem',
     [theme.breakpoints.up('sm')]: {
       maxWidth: '70%'
+    },
+    '&:last-child': {
+      marginBottom: '1rem'
     }
   },
   infoRow: {
@@ -133,4 +142,7 @@ const styles = theme => ({
   }
 })
 
-export default compose(withRoot, withData)(withStyles(styles)(Faculty))
+export default compose(
+  withRoot,
+  withData
+)(withStyles(styles)(Faculty))


### PR DESCRIPTION
_lib/queries/profile.js_
* Removed the `!` from `query ProfileQuery($name: String!)`, which stopped all GraphQL errors on _faculty.js_.

_pages/faculty.js_
* Iterate over all of `data[this.props.type].edges` instead of using only `edges[0]`.
  * To do this I used `.map(({node: facultyMember}) =>` and replaced all mentions of `faculty` with `facultyMember`.
* Move `imgRegex` section to inside `return` statement to dynamically apply it to each `node.content` not just `edges[0].node.content`.
* Replace `thumbnail`, `medium`, `imageW`, and all that jazz with `getImageData`, `getAllImageData`, and `getSrcSet`.
  * My reasoning behind this is that the original functions were very redundant and did not produce useable urls.
  * They also would likely have taken more time to perform, as they perform each `.find` search twice since there were two functions, one that returns the url and one that returns the width.
* I also separated each faculty member with a `marginBottom` of `4rem`, and on the `:last-child`, I used a margin of `1rem`.

![screenshot 2018-07-16 at 12 34 59 am](https://user-images.githubusercontent.com/19195374/42745454-2ea034ae-8890-11e8-894b-d8cd7d3fd2e9.png)
![screenshot 2018-07-16 at 12 35 07 am](https://user-images.githubusercontent.com/19195374/42745459-34119cca-8890-11e8-80c5-77f5e7f5ef86.png)
