### PR TITLE
Add title attribute to Menu Button, add title element to searchSVG

### DIFF
--- a/components/AppBar.js
+++ b/components/AppBar.js
@@ -150,6 +150,7 @@ class ButtonAppBar extends Component {
               <IconButton
                 className={classes.menuButton}
                 aria-label="Menu"
+                title="Menu"
                 onClick={toggleDrawer}
               >
                 <MenuIcon />
@@ -208,6 +209,7 @@ class ButtonAppBar extends Component {
                       className={classes.searchSVG}
                       onClick={this.onSearchClick}
                     >
+                      <title>Search Franciscan</title>
                       <path
                         xmlns="http://www.w3.org/2000/svg"
                         d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"


### PR DESCRIPTION
* Added `title` attribute to the `<IconButton>` that wraps around `<MenuIcon />`.
  * `title='Menu'`
* Added `<title>` element to the `<SvgIcon>` with class `classes.searchSVG`.
  * `<title>Search Franciscan</title>`