### PR TITLE
Style/material ui grid faculty list

### DIFF
--- a/components/FacultyListItem.js
+++ b/components/FacultyListItem.js
@@ -35,7 +35,9 @@ const styles = theme => ({
   portraitWrapper: {
     height: '100%',
     width: '50%',
-    overflow: 'hidden'
+    overflow: 'hidden',
+    borderTopRightRadius: '4px',
+    borderBottomRightRadius: '4px'
   },
   portrait: {
     objectFit: 'cover',

--- a/components/FacultyListItem.js
+++ b/components/FacultyListItem.js
@@ -10,27 +10,41 @@ import Paper from '@material-ui/core/Paper'
 
 const styles = theme => ({
   card: {
+    height: '250px',
     [theme.breakpoints.down('xl')]: {
       maxWidth: '600px'
     }
   },
   cardContent: {
     display: 'flex',
-    justifyContent: 'space-between'
+    justifyContent: 'space-between',
+    height: '100%',
+    width: '100%'
   },
-  media: {
-    minHeight: '280px',
-    [theme.breakpoints.up('xl')]: {
-      minHeight: '1366px'
-    },
-    [theme.breakpoints.up('lg')]: {
-      minHeight: 500
-    }
-  },
+  // media: {
+  //   minHeight: '280px',
+  //   [theme.breakpoints.up('xl')]: {
+  //     minHeight: '1366px'
+  //   },
+  //   [theme.breakpoints.up('lg')]: {
+  //     minHeight: 500
+  //   }
+  // },
   quote: {
     fontSize: '16px',
     paddingLeft: '8px',
     borderLeft: '4px solid rgba(0, 0, 0, 0.24)'
+  },
+  portraitWrapper: {
+    height: '100%',
+    width: '50%',
+    overflow: 'hidden'
+  },
+  portrait: {
+    objectFit: 'cover',
+    objectPosition: 'top',
+    width: '100%',
+    height: '100% !important'
   }
 })
 
@@ -41,7 +55,9 @@ class FacultyListItem extends Component {
     return (
       <Grid item xs={12} sm={9} md={6} lg={4} xl={3} className={classes.card}>
         <Paper className={classes.cardContent}>
-          <CardContent>
+          <CardContent
+            style={{ width: imageObj ? 'calc(50% - 48px)' : 'auto' }}
+          >
             <Typography variant="headline" component="h2">
               {profileName}
             </Typography>
@@ -62,7 +78,15 @@ class FacultyListItem extends Component {
               </CardActions>
             )}
           </CardContent>
-          {imageObj && <img src={imageObj.sourceUrl} alt={imageObj.altText} />}
+          {imageObj && (
+            <div className={classes.portraitWrapper}>
+              <img
+                src={imageObj.sourceUrl}
+                alt={imageObj.altText}
+                className={classes.portrait}
+              />
+            </div>
+          )}
         </Paper>
       </Grid>
     )

--- a/components/FacultyListItem.js
+++ b/components/FacultyListItem.js
@@ -11,9 +11,7 @@ import Paper from '@material-ui/core/Paper'
 const styles = theme => ({
   card: {
     height: '250px',
-    [theme.breakpoints.down('xl')]: {
-      maxWidth: '600px'
-    }
+    maxWidth: '600px'
   },
   cardContent: {
     display: 'flex',
@@ -30,10 +28,18 @@ const styles = theme => ({
   //     minHeight: 500
   //   }
   // },
+  name: {
+    [theme.breakpoints.down('xs')]: {
+      fontSize: '20px'
+    }
+  },
   quote: {
     fontSize: '16px',
     paddingLeft: '8px',
-    borderLeft: '4px solid rgba(0, 0, 0, 0.24)'
+    borderLeft: '4px solid rgba(0, 0, 0, 0.24)',
+    [theme.breakpoints.down('xs')]: {
+      fontSize: '14px'
+    }
   },
   portraitWrapper: {
     height: '100%',
@@ -45,6 +51,15 @@ const styles = theme => ({
     objectPosition: '0px 22%',
     width: '100%',
     height: '100% !important'
+  },
+  textContent: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between'
+  },
+  actions: {
+    marginTop: 'auto',
+    paddingLeft: '0'
   }
 })
 
@@ -56,9 +71,14 @@ class FacultyListItem extends Component {
       <Grid item xs={12} sm={9} md={6} lg={4} xl={3} className={classes.card}>
         <Paper className={classes.cardContent}>
           <CardContent
-            style={{ width: imageObj ? 'calc(50% - 48px)' : 'auto' }}
+            className={classes.textContent}
+            style={{ width: imageObj ? 'calc(50% - 24px)' : 'auto' }}
           >
-            <Typography variant="headline" component="h2">
+            <Typography
+              variant="headline"
+              component="h2"
+              className={classes.name}
+            >
               {profileName}
             </Typography>
             {jobTitle && (
@@ -67,7 +87,7 @@ class FacultyListItem extends Component {
               </Typography>
             )}
             {profileLink && (
-              <CardActions>
+              <CardActions className={classes.actions}>
                 <Fragment>
                   <Link prefetch href={profileLink}>
                     <Button size="small" color="primary">

--- a/components/FacultyListItem.js
+++ b/components/FacultyListItem.js
@@ -5,10 +5,16 @@ import { withStyles } from '@material-ui/core/styles'
 import Typography from '@material-ui/core/Typography'
 import Link from 'next/link'
 import React, { Component, Fragment } from 'react'
+import Grid from '@material-ui/core/Grid'
+import Paper from '@material-ui/core/Paper'
 
 const styles = theme => ({
   card: {
-    width: '100%',
+    [theme.breakpoints.down('xl')]: {
+      maxWidth: '600px'
+    }
+  },
+  cardContent: {
     display: 'flex',
     justifyContent: 'space-between'
   },
@@ -33,8 +39,8 @@ class FacultyListItem extends Component {
     const { classes, profileName, profileLink, jobTitle, imageObj } = this.props
 
     return (
-      <div className={classes.card}>
-        <div className={classes.textContent}>
+      <Grid item xs={12} sm={9} md={6} lg={4} xl={3} className={classes.card}>
+        <Paper className={classes.cardContent}>
           <CardContent>
             <Typography
               variant="headline"
@@ -52,21 +58,21 @@ class FacultyListItem extends Component {
                 }}
               />
             )}
+            {profileLink && (
+              <CardActions>
+                <Fragment>
+                  <Link prefetch href={profileLink}>
+                    <Button size="small" color="primary">
+                      Learn More
+                    </Button>
+                  </Link>
+                </Fragment>
+              </CardActions>
+            )}
           </CardContent>
-          {profileLink && (
-            <CardActions>
-              <Fragment>
-                <Link prefetch href={profileLink}>
-                  <Button size="small" color="primary">
-                    Learn More
-                  </Button>
-                </Link>
-              </Fragment>
-            </CardActions>
-          )}
-        </div>
-        {imageObj && <img src={imageObj.sourceUrl} alt={imageObj.altText} />}
-      </div>
+          {imageObj && <img src={imageObj.sourceUrl} alt={imageObj.altText} />}
+        </Paper>
+      </Grid>
     )
   }
 }

--- a/components/FacultyListItem.js
+++ b/components/FacultyListItem.js
@@ -59,6 +59,8 @@ const styles = theme => ({
 class FacultyListItem extends Component {
   render () {
     const { classes, profileName, profileLink, jobTitle, imageObj } = this.props
+    const decodeHTML = str =>
+      str.replace(/&#(\d+);/g, (_, p1) => String.fromCharCode(p1))
 
     return (
       <Grid item xs={12} sm={9} md={6} lg={4} xl={3} className={classes.card}>
@@ -72,11 +74,11 @@ class FacultyListItem extends Component {
               component="h2"
               className={classes.name}
             >
-              {profileName}
+              {decodeHTML(profileName)}
             </Typography>
             {jobTitle && (
               <Typography component="span" className={classes.quote}>
-                {jobTitle}
+                {decodeHTML(jobTitle)}
               </Typography>
             )}
             {profileLink && (

--- a/components/FacultyListItem.js
+++ b/components/FacultyListItem.js
@@ -19,15 +19,6 @@ const styles = theme => ({
     height: '100%',
     width: '100%'
   },
-  // media: {
-  //   minHeight: '280px',
-  //   [theme.breakpoints.up('xl')]: {
-  //     minHeight: '1366px'
-  //   },
-  //   [theme.breakpoints.up('lg')]: {
-  //     minHeight: 500
-  //   }
-  // },
   name: {
     [theme.breakpoints.down('xs')]: {
       fontSize: '20px'

--- a/components/FacultyListItem.js
+++ b/components/FacultyListItem.js
@@ -42,21 +42,13 @@ class FacultyListItem extends Component {
       <Grid item xs={12} sm={9} md={6} lg={4} xl={3} className={classes.card}>
         <Paper className={classes.cardContent}>
           <CardContent>
-            <Typography
-              variant="headline"
-              component="h2"
-              dangerouslySetInnerHTML={{
-                __html: profileName
-              }}
-            />
+            <Typography variant="headline" component="h2">
+              {profileName}
+            </Typography>
             {jobTitle && (
-              <Typography
-                component="span"
-                className={classes.quote}
-                dangerouslySetInnerHTML={{
-                  __html: jobTitle
-                }}
-              />
+              <Typography component="span" className={classes.quote}>
+                {jobTitle}
+              </Typography>
             )}
             {profileLink && (
               <CardActions>

--- a/components/FacultyListItem.js
+++ b/components/FacultyListItem.js
@@ -42,7 +42,7 @@ const styles = theme => ({
   },
   portrait: {
     objectFit: 'cover',
-    objectPosition: 'top',
+    objectPosition: '0px 22%',
     width: '100%',
     height: '100% !important'
   }

--- a/components/FacultyListItem.js
+++ b/components/FacultyListItem.js
@@ -4,7 +4,7 @@ import CardContent from '@material-ui/core/CardContent'
 import { withStyles } from '@material-ui/core/styles'
 import Typography from '@material-ui/core/Typography'
 import Link from 'next/link'
-import React, { Component, Fragment } from 'react'
+import React, { Fragment } from 'react'
 import Grid from '@material-ui/core/Grid'
 import Paper from '@material-ui/core/Paper'
 
@@ -56,56 +56,54 @@ const styles = theme => ({
   }
 })
 
-class FacultyListItem extends Component {
-  render () {
-    const { classes, profileName, profileLink, jobTitle, imageObj } = this.props
-    const decodeHTML = str =>
-      str.replace(/&#(\d+);/g, (_, p1) => String.fromCharCode(p1))
+const FacultyListItem = props => {
+  const { classes, profileName, profileLink, jobTitle, imageObj } = props
+  const decodeHTML = str =>
+    str.replace(/&#(\d+);/g, (_, p1) => String.fromCharCode(p1))
 
-    return (
-      <Grid item xs={12} sm={9} md={6} lg={4} xl={3} className={classes.card}>
-        <Paper className={classes.cardContent}>
-          <CardContent
-            className={classes.textContent}
-            style={{ width: imageObj ? 'calc(50% - 24px)' : 'auto' }}
+  return (
+    <Grid item xs={12} sm={9} md={6} lg={4} xl={3} className={classes.card}>
+      <Paper className={classes.cardContent}>
+        <CardContent
+          className={classes.textContent}
+          style={{ width: imageObj ? 'calc(50% - 24px)' : 'auto' }}
+        >
+          <Typography
+            variant="headline"
+            component="h2"
+            className={classes.name}
           >
-            <Typography
-              variant="headline"
-              component="h2"
-              className={classes.name}
-            >
-              {decodeHTML(profileName)}
+            {decodeHTML(profileName)}
+          </Typography>
+          {jobTitle && (
+            <Typography component="span" className={classes.quote}>
+              {decodeHTML(jobTitle)}
             </Typography>
-            {jobTitle && (
-              <Typography component="span" className={classes.quote}>
-                {decodeHTML(jobTitle)}
-              </Typography>
-            )}
-            {profileLink && (
-              <CardActions className={classes.actions}>
-                <Fragment>
-                  <Link prefetch href={profileLink}>
-                    <Button size="small" color="primary">
-                      Learn More
-                    </Button>
-                  </Link>
-                </Fragment>
-              </CardActions>
-            )}
-          </CardContent>
-          {imageObj && (
-            <div className={classes.portraitWrapper}>
-              <img
-                src={imageObj.sourceUrl}
-                alt={imageObj.altText}
-                className={classes.portrait}
-              />
-            </div>
           )}
-        </Paper>
-      </Grid>
-    )
-  }
+          {profileLink && (
+            <CardActions className={classes.actions}>
+              <Fragment>
+                <Link prefetch href={profileLink}>
+                  <Button size="small" color="primary">
+                    Learn More
+                  </Button>
+                </Link>
+              </Fragment>
+            </CardActions>
+          )}
+        </CardContent>
+        {imageObj && (
+          <div className={classes.portraitWrapper}>
+            <img
+              src={imageObj.sourceUrl}
+              alt={imageObj.altText}
+              className={classes.portrait}
+            />
+          </div>
+        )}
+      </Paper>
+    </Grid>
+  )
 }
 
 export default withStyles(styles)(FacultyListItem)

--- a/pages/faculty-list.js
+++ b/pages/faculty-list.js
@@ -65,23 +65,22 @@ class FacultyList extends Component {
               data['facultyDepartments'].edges[0].node.faculty.edges
 
             return (
-              <div className={classes.contentContainer}>
+              <Grid
+                container
+                className={classes.gridItemFix}
+                justify="center"
+                spacing={16}
+              >
                 {facultyData.map(faculty => (
-                  <Grid
+                  <FacultyListItem
                     key={faculty.node.slug}
-                    item
-                    className={classes.gridItemFix}
-                    xs={12}
-                  >
-                    <FacultyListItem
-                      profileName={faculty.node.displayNameField.value}
-                      profileLink={`/faculty/${faculty.node.slug}`}
-                      jobTitle={faculty.node.jobTitleField.value}
-                      imageObj={faculty.node.featuredImage}
-                    />
-                  </Grid>
+                    profileName={faculty.node.displayNameField.value}
+                    profileLink={`/faculty/${faculty.node.slug}`}
+                    jobTitle={faculty.node.jobTitleField.value}
+                    imageObj={faculty.node.featuredImage}
+                  />
                 ))}
-              </div>
+              </Grid>
             )
           }}
         </Query>
@@ -90,4 +89,7 @@ class FacultyList extends Component {
   }
 }
 
-export default compose(withRoot, withData)(withStyles(styles)(FacultyList))
+export default compose(
+  withRoot,
+  withData
+)(withStyles(styles)(FacultyList))

--- a/pages/faculty-list.js
+++ b/pages/faculty-list.js
@@ -12,6 +12,7 @@ import withData from '../lib/withData'
 const styles = theme => ({
   gridItemFix: {
     width: '100%',
+    margin: '0',
     padding: '16px',
     [theme.breakpoints.down('sm')]: {
       padding: '8px'


### PR DESCRIPTION
Closes #141 #147 

I built this assuming that __"materialUI grid components"__ meant Material style elevated cards using `<Paper>`

### Changes to `components/FacultyListItem.js`:
 * Outer divs:
   * are replaced with `Grid item` and `Paper` respectively
   * sized to `250 x max(600)`
 * Typography components
   * remove __dangerouslySetInnerHTML__ and insert data as regular ol' text
   * at breakpoint `xs` use slightly smaller font size
 * CardActions
   * moved next to Typography components in code
   * moved to the bottom of card visually
   * removed `padding-left` to align it visually with other text on the card
 * Portrait
   * takes up `50%` of card width
   * spans from top to bottom of the card
   * `object-fit: cover` allows all images to take up the same space and maintain aspect ratio
   * curved outer corners to match edges of the card

### Changes to `pages/faculty-list.js`:
 * Outer div
   * replace with `Grid container`
     * spacing of `16`
     * items within are centered
 * FacultyListItem
   * is no longer wrapped in `Grid item` because that is handled in the component

![image](https://user-images.githubusercontent.com/19195374/42934373-3b145730-8b04-11e8-9544-ed94acf7bf57.png)

__Note:__ I didn't place the portraits on top on smaller screens, mostly because these are portraits and with material card design it becomes difficult to keep it a part of the card while being on top.

Here's what it looks like with Google Pixel 2 XL size:

![image](https://user-images.githubusercontent.com/19195374/42934730-130ee830-8b05-11e8-9367-5177ced6686d.png)
