### PR TITLE
Issue#152: deletes '-' and 'page' from type in search

### DIFF
--- a/pages/search.js
+++ b/pages/search.js
@@ -269,7 +269,9 @@ class Search extends Component {
                   .filter(item => item.acf.search_url !== null)
                   .map(item => (
                     <div key={item.id} className={classes.searchResult}>
-                      <span className={classes.type}>{item.type}</span>
+                      <span className={classes.type}>
+                        {item.type.replace(/-|page/gi, ' ').trim()}
+                      </span>
                       <a
                         href={item.acf.search_url}
                         className={classes.title}


### PR DESCRIPTION
I resolved the issue with the RegExp:    
<span className={classes.type}>
      {**item.type.replace(/-|page/gi, ' ').trim()**}
</span>